### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/self-action.yml
+++ b/.github/workflows/self-action.yml
@@ -5,6 +5,9 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -16,4 +19,3 @@ jobs:
         uses: ./ 
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-


### PR DESCRIPTION
Potential fix for [https://github.com/GitHubSecurityLab/codeql-extractor-bicep/security/code-scanning/3](https://github.com/GitHubSecurityLab/codeql-extractor-bicep/security/code-scanning/3)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the provided workflow, it appears that the workflow primarily reads repository contents and uses the `GITHUB_TOKEN` for authentication. Therefore, the permissions can be limited to `contents: read`.

The `permissions` block should be added at the root level of the workflow file to apply to all jobs in the workflow. This ensures that all jobs inherit the same minimal permissions unless explicitly overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
